### PR TITLE
Feat/simplify composing

### DIFF
--- a/package/react/package.json
+++ b/package/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enun/react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package/react/src/createHook.ts
+++ b/package/react/src/createHook.ts
@@ -1,12 +1,10 @@
-import { ComposeMap, Store, StoreImpl } from "@enun/store";
+import { Store, StoreImpl } from "@enun/store";
 import { useMemo } from "react";
 import { useStore as useZustandStore } from "zustand";
 
 import { useStoreFromContext } from "./context/StoreContext";
 
-const createHook = <T extends object, Deps extends object, Composed extends ComposeMap>(
-  store: Store<T, Deps, Composed>,
-) => {
+const createHook = <T extends object, Deps extends object>(store: Store<T, Deps>) => {
   const useStore = (props?: Deps) => {
     const fromContext = useStoreFromContext<T>({ fingerPrint: store.fingerPrint });
     const impl = useMemo(() => {

--- a/package/react/src/useStoreInit.ts
+++ b/package/react/src/useStoreInit.ts
@@ -1,10 +1,7 @@
-import { ComposeMap, Store } from "@enun/store";
+import { Store } from "@enun/store";
 import { useEffect, useMemo } from "react";
 
-export const useStoreInit = <T extends object, Deps extends object, Composed extends ComposeMap>(
-  store: Store<T, Deps, Composed>,
-  deps: Deps,
-) => {
+export const useStoreInit = <T extends object, Deps extends object>(store: Store<T, Deps>, deps: Deps) => {
   const storeImpl = useMemo(() => {
     return store.use(deps);
   }, [store.hashKey(deps)]);

--- a/package/store/package.json
+++ b/package/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enun/store",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/package/store/src/cache/CacheManager.ts
+++ b/package/store/src/cache/CacheManager.ts
@@ -12,7 +12,7 @@ class CacheManager {
   private get<T>({ key }: { key: string }) {
     return this.cacheMap.get(key) as T | undefined;
   }
-  private set<T>({ key, value }: { key: string; value: T }) {
+  private set({ key, value }: { key: string; value: unknown }) {
     this.cacheMap.set(key, value);
   }
   private remove({ key }: { key: string }) {

--- a/package/store/src/create.ts
+++ b/package/store/src/create.ts
@@ -1,7 +1,7 @@
-import { ComposeMap, StoreBuilder } from "./store";
+import { StoreBuilder } from "./store";
 
 const create = <T extends object, Deps extends object = object>() => {
-  const builder = new StoreBuilder<T, Deps, ComposeMap>({});
+  const builder = new StoreBuilder<T, Deps>({});
   return builder;
 };
 

--- a/package/store/src/store/StoreBuilder.ts
+++ b/package/store/src/store/StoreBuilder.ts
@@ -1,43 +1,31 @@
 import { Store } from "./Store";
-import { ComposeMap, Composer, DefineStore, GetKeyDeps } from "./type";
+import { DefineStore, GetKeyDeps } from "./type";
 
-interface StoreBuilderParam<T extends object, Deps extends object, Composed extends ComposeMap> {
-  defineStore?: DefineStore<T, Deps, Composed>;
+interface StoreBuilderParam<T extends object, Deps extends object> {
+  defineStore?: DefineStore<T, Deps>;
   getKeyDeps?: GetKeyDeps<Deps>;
-  composeStore?: Composer<Deps, Composed>;
 }
 
-class StoreBuilder<T extends object, Deps extends object, Composed extends ComposeMap> {
-  private defineStore?: DefineStore<T, Deps, Composed>;
+class StoreBuilder<T extends object, Deps extends object> {
+  private defineStore?: DefineStore<T, Deps>;
   private getKeyDeps?: GetKeyDeps<Deps>;
-  private composeStore?: Composer<Deps, Composed>;
 
-  constructor({ defineStore, getKeyDeps, composeStore }: StoreBuilderParam<T, Deps, Composed>) {
+  constructor({ defineStore, getKeyDeps }: StoreBuilderParam<T, Deps>) {
     this.defineStore = defineStore;
     this.getKeyDeps = getKeyDeps;
-    this.composeStore = composeStore;
   }
 
-  public define(defineFn: DefineStore<T, Deps, Composed>) {
+  public define(defineFn: DefineStore<T, Deps>) {
     this.defineStore = defineFn;
-    return new Store<T, Deps, Composed>({
+    return new Store<T, Deps>({
       defineStore: this.defineStore,
       getKeyDeps: this.getKeyDeps,
-      composeStore: this.composeStore,
     });
   }
 
   public key(getFn: GetKeyDeps<Deps>) {
-    return new StoreBuilder<T, Deps, Composed>({
+    return new StoreBuilder<T, Deps>({
       getKeyDeps: getFn,
-      composeStore: this.composeStore,
-    });
-  }
-
-  public compose<C extends ComposeMap>(composer: Composer<Deps, C>) {
-    return new StoreBuilder<T, Deps, C>({
-      getKeyDeps: this.getKeyDeps,
-      composeStore: composer,
     });
   }
 }

--- a/package/store/src/store/type.ts
+++ b/package/store/src/store/type.ts
@@ -1,15 +1,18 @@
 import { StoreApi } from "zustand";
 
 import { RawKey } from "../cache";
-import { StoreImpl } from "./StoreImpl";
 
-interface DefineStoreParam<T extends object, Deps extends object, Composed extends ComposeMap> {
-  injected: Deps;
-  composed: Composed;
-  set: Setter<T>;
+interface Destroyable {
+  destroy: () => void;
 }
-interface DefineStore<T extends object, Deps extends object, Composed extends ComposeMap> {
-  (param: DefineStoreParam<T, Deps, Composed>): T;
+
+interface DefineStoreParam<T extends object, Deps extends object> {
+  injected: Deps;
+  set: Setter<T>;
+  compose: Composer;
+}
+interface DefineStore<T extends object, Deps extends object> {
+  (param: DefineStoreParam<T, Deps>): T;
 }
 interface GetKeyDeps<Deps extends object> {
   (prev: Deps): RawKey;
@@ -19,16 +22,16 @@ interface Setter<T> {
   (partial: T | Partial<T> | ((state: T) => T | Partial<T>), replace?: false): void;
   (state: T | ((state: T) => T), replace: true): void;
 }
+interface Composer {
+  <T extends Destroyable>(destroyable: T): T;
+}
 interface Subscriber<T> {
   (state: T, prevState: T): void;
 }
-
-type ComposeMap = Record<string, StoreImpl<object>>;
-type Composer<Deps, Composed extends ComposeMap> = (store: Deps) => Composed;
 
 /**
  * External
  */
 type ZustandStore<T> = StoreApi<T>;
 
-export type { ComposeMap, Composer, DefineStore, DefineStoreParam, GetKeyDeps, Setter, Subscriber, ZustandStore };
+export type { Composer, DefineStore, DefineStoreParam, Destroyable, GetKeyDeps, Setter, Subscriber, ZustandStore };

--- a/package/store/src/store/utility.ts
+++ b/package/store/src/store/utility.ts
@@ -1,8 +1,6 @@
 import { Store } from "./Store";
-import { ComposeMap } from "./type";
 
-type TypeOf<S extends Store<object, object, ComposeMap>> = S extends Store<infer T, object, ComposeMap> ? T : never;
-type DepsOf<S extends Store<object, object, ComposeMap>> =
-  S extends Store<object, infer Deps, ComposeMap> ? Deps : never;
+type TypeOf<S extends Store<object, object>> = S extends Store<infer T, object> ? T : never;
+type DepsOf<S extends Store<object, object>> = S extends Store<object, infer Deps> ? Deps : never;
 
 export type { DepsOf, TypeOf };


### PR DESCRIPTION
## 작업 내용
`compose(합성)`는 하나의 스토어 내부에서 다른 스토어를 사용하는 것을 도와주는 기능입니다. 현 버전에서(0.x), 사용이 끝난 스토어는 직접 `destroy` 해주어야 정상적으로 GC 되는데, 특정 스토어의 내부에서 사용된 스토어들에는 직접 접근하여 `destroy`할 수 없습니다. `compose`는 외부 스토어가 `destroy`될 때, 내부에서 사용된 스토어들도 함께 `destroy` 시켜줍니다.


### 코드 예시
기존에는 합성할 store를 먼저 명시해야 했습니다.

```ts
// 기존 코드 예시
const TextWithCountStore = create<TextWithCountStore, { text: string }>()
  .compose(({ text }) => ({
    textStore: TextStore.appendKey({ purpose: "countTest" }).local().use({ text }),
  }))
  .define(({ injected, composed, set }) => {
    composed.textStore.subscribe(({ text }) => {
    // 후략

```

 이제는 `defineFn`에 인자로 전달되는 `compose`라는 함수를 이용하여 보다 간편하게 합성할 수 있습니다.

```ts
// 새로운 예시
const TextWithCountStore = create<TextWithCountStore, { text: string }>().define(({ injected, compose, set }) => {
  /**
   *  `compose` 함수는 `StoreImpl`을 인자로 받아 외부의 store와 `destroy` 동작이 연결된 `StoreImpl`를 반환한다.
   */
  const textStore = compose(TextStore.appendKey({ purpose: "countTest" }).local().use({ text: injected.text }));
  textStore.subscribe(({ text }) => {
  // 후략
```


### 새 방식의 장점
- 스토어의 배열이나 중첩된 스토어도 합성할 수 있습니다.
- 스토어 정의 문법이 간단해집니다.
- `Store`가 `CompositionMap`과 같은 타입을 더 이상 기억하지 않아도 되어, 스토어 관련 패키지의 타입 관련 코드가 간단해집니다.


## 나중에 할 일
- `destroy`로 직접 store의 메모리를 해제시키지 않아도, `StoreImpl`을 가리키는 reference가 모두 무효화되면(클로저의 소멸, 리액트 컴포넌트의 unmount 등) 자동으로 GC될 수 있도록 `cacheMap`의 동작 방식을 변경하기.
- Store의 생명주기(define - use - destroy)를 명시적으로 드러내어 각 주기마다 원하는 side effect를 추가할 수 있도록 하기.

## 버전
핵심 문법에 변경이 생겨 마이너 버전 업그레이드.
- `@enun/store`: 0.2.0
- `@enun/react`: 0.2.0